### PR TITLE
Update eloquent-entity-translation.stub

### DIFF
--- a/Scaffold/Module/stubs/eloquent-entity-translation.stub
+++ b/Scaffold/Module/stubs/eloquent-entity-translation.stub
@@ -6,5 +6,5 @@ class $CLASS_NAME$Translation extends Model
 {
     public $timestamps = false;
     protected $fillable = [];
-    protected $table = '$LOWERCASE_MODULE_NAME$__$PLURAL_LOWERCASE_CLASS_NAME$_translations';
+    protected $table = '$LOWERCASE_MODULE_NAME$__$LOWERCASE_CLASS_NAME$_translations';
 }


### PR DESCRIPTION
The scaffold for the migrations uses 'singular__singular_translations', whereas this was generating a 'singular__plural_translations' table name in the entity.

(see https://github.com/AsgardCms/Workshop/blob/develop/Scaffold/Module/stubs/create-translation-table-migration.stub#L15)