### PR TITLE
Removed Menu Module as a dependency 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "php": ">=5.4",
     "composer/installers": "~1.0",
     "asgardcms/core-module": "~1.0",
-    "asgardcms/menu-module": "~1.0",
     "pingpong/modules": "dev-feature/5.1"
   },
   "require-dev": {


### PR DESCRIPTION
Doesn't seem to be used anywhere inside the Workshop module, so not really a dependency