### PR TITLE
Fix binding placeholder

### DIFF
--- a/Scaffold/Module/stubs/route-resource.stub
+++ b/Scaffold/Module/stubs/route-resource.stub
@@ -1,4 +1,4 @@
-    $router->bind('$PLURAL_LOWERCASE_CLASS_NAME$', function ($id) {
+    $router->bind('$LOWERCASE_CLASS_NAME$', function ($id) {
         return app('Modules\$MODULE_NAME$\Repositories\$CLASS_NAME$Repository')->find($id);
     });
     get('$PLURAL_LOWERCASE_CLASS_NAME$', [


### PR DESCRIPTION
In previous PR i must have forgotten to change binding placeholder.
Generated module route file expects ``$LOWERCASE_MODULE_NAME$``, but it binds to ``$PLURAL_LOWERCASE_CLASS_NAME$``

Reported at forum [by matth__](http://forum.asgardcms.com/topic/104/wrong-route-model-binding-for-workshop-module)