### PR TITLE
Added Elixir option to ThemeScaffold

### DIFF
--- a/Console/ThemeScaffoldCommand.php
+++ b/Console/ThemeScaffoldCommand.php
@@ -25,7 +25,23 @@ class ThemeScaffoldCommand extends Command
 
         $type = $this->choice('Would you like to create a front end or backend theme ?', ['Frontend', 'Backend'], 0);
 
-        $this->themeScaffold->setName($name)->setVendor($vendor)->forType(strtolower($type))->generate();
+        $withElixir = $this->choice('Would you like to use Elixir?', ['Yes', 'No'], 1);
+
+        var_dump($withElixir);
+        if ($withElixir == 'Yes') {
+            $elixir = $this->ask('Please enter the version of Elixir you want in the following format: 0.0.0');
+
+            $gulp = $this->ask('Please enter the version of gulp you want in the following format: 0.0.0');
+
+            $this->themeScaffold
+                ->setName($name)
+                ->setVendor($vendor)
+                ->forType(strtolower($type))
+                ->withElixir($elixir, $gulp)
+                ->generate();
+        } else {
+            $this->themeScaffold->setName($name)->setVendor($vendor)->forType(strtolower($type))->generate();
+        }
 
         $this->info("Generated a fresh theme called [$themeName]. You'll find it in the Themes/ folder");
     }

--- a/Scaffold/Theme/FileTypes/GulpFileJs.php
+++ b/Scaffold/Theme/FileTypes/GulpFileJs.php
@@ -1,0 +1,19 @@
+<?php namespace Modules\Workshop\Scaffold\Theme\FileTypes;
+
+use Modules\Workshop\Scaffold\Theme\Traits\FindsThemePath;
+
+class GulpFileJs extends BaseFileType implements FileType
+{
+    use FindsThemePath;
+
+    /**
+     * Generate the current file type
+     * @return string
+     */
+    public function generate()
+    {
+        $stub = $this->finder->get(__DIR__ . '/../stubs/gulpFileJs.stub');
+
+        $this->finder->put($this->themePathForFile($this->options['name'], 'gulpfile.js'), $stub);
+    }
+}

--- a/Scaffold/Theme/FileTypes/PackageJson.php
+++ b/Scaffold/Theme/FileTypes/PackageJson.php
@@ -1,0 +1,36 @@
+<?php namespace Modules\Workshop\Scaffold\Theme\FileTypes;
+
+use Modules\Workshop\Scaffold\Theme\Traits\FindsThemePath;
+
+class PackageJson extends BaseFileType implements FileType
+{
+    use FindsThemePath;
+
+    /**
+     * Generate the current file type
+     * @return string
+     */
+    public function generate()
+    {
+        $stub = $this->finder->get(__DIR__ . '/../stubs/packageJson.stub');
+
+        $stub = $this->replaceContentInStub($stub);
+
+        $this->finder->put($this->themePathForFile($this->options['name'], 'package.json'), $stub);
+    }
+
+    public function replaceContentInStub($stub)
+    {
+        return str_replace(
+            [
+                '{{gulp-version}}',
+                '{{elixir-version}}',
+            ],
+            [
+                $this->options['gulp'],
+                $this->options['elixir'],
+            ],
+            $stub
+        );
+    }
+}

--- a/Scaffold/Theme/ThemeScaffold.php
+++ b/Scaffold/Theme/ThemeScaffold.php
@@ -108,4 +108,27 @@ class ThemeScaffold
     {
         $this->files = $files;
     }
+
+    /**
+     * @param string $elixir Version of Elixir to write to package.json
+     * @param string $gulp Version of gulp to write to package.json
+     * @return $this
+     */
+    public function withElixir($elixir="*", $gulp="*")
+    {
+        if (empty($elixir)) {
+            $elixir = '*';
+        }
+
+        if (empty($gulp)) {
+            $gulp = '*';
+        }
+
+        $this->options['elixir'] = $elixir;
+        $this->options['gulp'] = $gulp;
+
+        $this->files = array_merge($this->files, ['packageJson','gulpFileJs']);
+
+        return $this;
+    }
 }

--- a/Scaffold/Theme/stubs/gulpfileJs.stub
+++ b/Scaffold/Theme/stubs/gulpfileJs.stub
@@ -1,0 +1,52 @@
+var gulp = require("gulp");
+var shell = require('gulp-shell');
+var elixir = require('laravel-elixir');
+var themeInfo = require('./theme.json');
+
+
+// configure Elixir to work from Theme dir
+elixir.config.assetsPath = 'resources';
+elixir.config.publicPath = 'assets';
+elixir.config.appPath = '../../app';
+
+
+/**
+ * Since all assets need to be published to the public/ folder
+ * you can use the following custom mix for Laravel Elixir
+ * @see https://asgardcms.com/docs/themes/usage#elixir
+ */
+elixir.extend('stylistPublish', function( theme ){
+
+    new elixir.Task('stylistPublish', function() {
+        return gulp.src('').pipe(shell([
+            'php ../../artisan stylist:publish ' + theme
+        ]));
+    });
+
+});
+
+
+/*
+ |--------------------------------------------------------------------------
+ | Elixir Asset Management
+ |--------------------------------------------------------------------------
+ |
+ | Elixir provides a clean, fluent API for defining some basic Gulp tasks
+ | for your Laravel application. By default, we are compiling the Sass
+ | file for our application, as well as publishing vendor resources.
+ |
+ */
+
+elixir(function (mix) {
+
+    /**
+     * Example of LESS based theme
+     * @see https://laravel.com/docs/5.2/elixir
+     */
+//    mix.less([
+//        "app.less", '.'
+//    ])
+//    .stylistPublish( themeInfo.name );
+
+    stylistPublish( themeInfo.name );
+});

--- a/Scaffold/Theme/stubs/packageJson.stub
+++ b/Scaffold/Theme/stubs/packageJson.stub
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "scripts": {
+    "prod": "gulp --production",
+    "dev": "gulp watch"
+  },
+  "devDependencies": {
+    "gulp": "{{gulp-version}}",
+    "laravel-elixir": "{{elixir-version}}"
+  }
+}

--- a/Tests/ThemeScaffoldTest.php
+++ b/Tests/ThemeScaffoldTest.php
@@ -43,6 +43,11 @@ class ThemeScaffoldTest extends BaseTestCase
         $this->scaffold->setName($this->testThemeName)->forType('frontend')->setVendor('asgardcms')->generate();
     }
 
+    private function generateFrontendThemeWithElixir($elixir, $gulp)
+    {
+        $this->scaffold->setName($this->testThemeName)->forType('frontend')->setVendor('asgardcms')->withElixir($elixir, $gulp)->generate();
+    }
+
     public function tearDown()
     {
         $this->finder->deleteDirectory($this->testThemePath);
@@ -178,5 +183,53 @@ class ThemeScaffoldTest extends BaseTestCase
         $this->assertTrue($this->finder->isFile($this->testThemePath . '/assets/css/.gitignore'));
         $this->assertTrue($this->finder->isFile($this->testThemePath . '/assets/js/.gitignore'));
         $this->assertTrue($this->finder->isFile($this->testThemePath . '/assets/images/.gitignore'));
+    }
+
+    /**
+     * @group elixir
+     * @test
+     */
+    public function it_does_not_create_elixir_files_when_option_is_no()
+    {
+        $this->generateFrontendTheme();
+
+        $this->assertFalse($this->finder->isFile($this->testThemePath . '/package.json'));
+        $this->assertFalse($this->finder->isFile($this->testThemePath . '/gulpfile.js'));
+    }
+
+    /**
+     * @group elixir
+     * @test
+     */
+    public function it_creates_elixir_files_when_option_is_yes_with_defaults()
+    {
+        $expectedPackageJsonFile = $this->testThemePath . '/package.json';
+        $expectedGulpFile = $this->testThemePath . '/gulpfile.js';
+
+        $this->generateFrontendThemeWithElixir(null, null);
+
+        $this->assertTrue($this->finder->isFile($expectedPackageJsonFile), "expect '" . $expectedPackageJsonFile . "' to be created.");
+        $this->assertTrue($this->finder->isFile($expectedGulpFile), "expect " . $expectedGulpFile . " to be created.");
+
+        $this->assertTrue(str_contains($this->finder->get($expectedPackageJsonFile), '"gulp": "*",'));
+        $this->assertTrue(str_contains($this->finder->get($expectedPackageJsonFile), '"laravel-elixir": "*"'));
+    }
+
+    /**
+     * @group elixir
+     * @test
+     */
+    public function it_creates_versioned_elixir_files_when_version_set()
+    {
+        $expectedPackageJsonFile = $this->testThemePath . '/package.json';
+        $expectedGulpFile = $this->testThemePath . '/gulpfile.js';
+
+        $this->generateFrontendThemeWithElixir('5.0.0', '^3.9.1');
+
+        $this->assertTrue($this->finder->isFile($expectedPackageJsonFile), "expect '" . $expectedPackageJsonFile . "' to be created.");
+        $this->assertTrue($this->finder->isFile($expectedGulpFile), "expect " . $expectedGulpFile . " to be created.");
+
+        $this->assertTrue(str_contains($this->finder->get($expectedPackageJsonFile), '"gulp": "^3.9.1",'));
+        $this->assertTrue(str_contains($this->finder->get($expectedPackageJsonFile), '"laravel-elixir": "5.0.0"'));
     }
 }


### PR DESCRIPTION
Not sure if this is something you'd want for this module. I was planning to put it in a separate one but thought I'd check in first to see if you'd prefer to have it as part of the existing ThemeScaffold. 

Added the option to include elixir as part of the theme scaffolding. During the setup you can choose to include elixir and specify the version if you like.

If you choose to include Elixir as part of the theme scaffolding it will be configured to look for source files in THEME_NAME/resources and generate your assets within your THEME_NAME/assets directory.

It also includes the 'stylistPublish' Elixir extension. An updated version of the snippet documented here: https://asgardcms.com/docs/themes/usage#elixir

New unit tests were added to make sure it's backwards compatible. No elixir files are created when you choose 'no' during setup. Tests were added to validate the elixir files get created as well when you choose 'yes' during setup.

To manually test:
```
php artisan asgard:theme:scaffold
// 1. 'vendor/themename' [Enter]
// 2. 'frontend' [Enter]
// 3. 'Yes' [Enter]
// 4. '*' [Enter]
// 5. '*' [Enter]
cd Themes/themename
npm install
// add a css or less file to be mixed in
gulp
// see the generated file in Themes/themename/assets
// see the published assets in public/themes/themename
```

The .php_cs file seems to be out-dated so I ran this (tried to match it up as best as I could)
```
php-cs-fixer fix . --rules=@PSR1,@PSR2,concat_with_spaces,ordered_imports,no_extra_consecutive_blank_lines,no_useless_return,no_unused_imports,no_whitespace_in_blank_lines --verbose --dry-run
```
Not sure if you're still following the PSR2 standards since most of the files failed the unix line endings test, so I left them as-is.