### PR TITLE
Fix Workshop group not showing if workshop.* permissions are denied

### DIFF
--- a/Sidebar/SidebarExtender.php
+++ b/Sidebar/SidebarExtender.php
@@ -51,7 +51,7 @@ class SidebarExtender implements \Maatwebsite\Sidebar\SidebarExtender
             });
 
             $group->authorize(
-                $this->auth->hasAccess('workshop.*')
+                $this->auth->hasAccess('workshop.*') or $this->auth->hasAccess('user.*') or $this->auth->hasAccess('setting.*')
             );
         });
 


### PR DESCRIPTION
If workshop.* permissions are denied, the entire group disappears, even if a user/role has permissions for user.* or setting.*.