### PR TITLE
Change API middleware to only check for a valid token

### DIFF
--- a/Config/permissions.php
+++ b/Config/permissions.php
@@ -7,9 +7,11 @@ return [
         'update' => 'workshop::modules.update resource',
         'disable' => 'workshop::modules.disable resource',
         'enable' => 'workshop::modules.enable resource',
+        'publish' => 'workshop::modules.publish assets'
     ],
     'workshop.themes' => [
         'index' => 'workshop::themes.list resource',
         'show' => 'workshop::themes.show resource',
+        'publish' => 'workshop::themes.publish assets'
     ],
 ];

--- a/Http/apiRoutes.php
+++ b/Http/apiRoutes.php
@@ -3,13 +3,15 @@
 use Illuminate\Routing\Router;
 
 /** @var Router $router */
-$router->group(['prefix' => 'workshop', 'middleware' => 'api.token.admin'], function (Router $router) {
+$router->group(['prefix' => 'workshop', 'middleware' => 'api.token'], function (Router $router) {
     $router->post('modules/{module}/publish', [
         'as' => 'api.workshop.module.publish',
         'uses' => 'ModulesController@publishAssets',
+        'middleware' => 'token-can:workshop.modules.publish',
     ]);
     $router->post('themes/{theme}/publish', [
         'as' => 'api.workshop.theme.publish',
         'uses' => 'ThemeController@publishAssets',
+        'middleware' => 'token-can:workshop.themes.publish',
     ]);
 });


### PR DESCRIPTION
As per https://github.com/AsgardCms/Platform/issues/229, any API action
was limited to people in the "Admin" group. If the group name was changed
or the user wasn't an admin they couldn't do any API action at all, even
if they had correct permissions.